### PR TITLE
add package io/ioutil

### DIFF
--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -230,6 +230,7 @@ package main
 
 import (
 	"fmt"
+        "io/ioutil"
 	"net/http"
 )
 


### PR DESCRIPTION
Hi, I'm studying go language. And I studied Go-Tutorial.
My envitonments is version 1.4.2, CONCURRENCY.md contents doesn't work.

```
./zipcode.go:19: undefined: ioutil
```

So, I add import package `io/ioutil`.
